### PR TITLE
Update header component

### DIFF
--- a/packages/client/src/presentation/components/header/index.tsx
+++ b/packages/client/src/presentation/components/header/index.tsx
@@ -19,37 +19,44 @@ interface StyleProps {
 const S = {
   header: styled.div`
     width: 100%;
-    min-width: 53px;
+    height: 44px;
     display: flex;
     justify-content: space-between;
     align-items: center;
-    padding: 12px;
+    padding: 6px 15px;
   `,
   title: styled.h1<StyleProps>`
     display: flex;
+    flex: 1;
     justify-content: center;
     align-items: center;
     width: 33.3333333%;
     font-size: 1.5rem;
     font-weight: bold;
+    height: 2rem;
+    line-height: 2rem;
     color: ${(props) => props.color};
   `,
   leftSide: styled.p`
     display: flex;
+    flex: 1;
     justify-content: flex-start;
     align-items: center;
     width: 33.3333333%;
-    font-size: 1rem;
-    font-weight: bold;
+    font-size: 1.125rem;
+    height: 2rem;
+    line-height: 2rem;
     color: ${(props) => props.color};
   `,
   rightSide: styled.p`
     display: flex;
+    flex: 1;
     justify-content: flex-end;
     align-items: center;
     width: 33.3333333%;
-    font-size: 1rem;
-    font-weight: bold;
+    font-size: 1.125rem;
+    height: 2rem;
+    line-height: 2rem;
     color: ${(props) => props.color};
   `,
 };

--- a/packages/client/src/presentation/views/main/index.tsx
+++ b/packages/client/src/presentation/views/main/index.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 import FloatingButton from '@/presentation/components/floatingButton';
 import Header from '@/presentation/components/header';
 import EmotionCalendar from '@/presentation/containers/emotionCalendar';
+import dayjs from 'dayjs';
 
 const say = (val: string) => () => console.log('say', val);
 
@@ -20,7 +21,7 @@ const currentS = {
 const MainView = () => (
   <div>
     <Header
-      title="2019"
+      title={ dayjs().format('YYYY') }
       leftSide="설정"
       rightSide="리마인드"
     />


### PR DESCRIPTION
기존에 만들어진 header component의 style들을 수정하였습니다.

![2020-01-19_21-57-17](https://user-images.githubusercontent.com/26288794/72681433-d8b7fb00-3b06-11ea-8636-4ba535b73692.jpg)

### 기능 설명
- 왼쪽 오른쪽은 string 및 component를 받아와 render 할 수 있스빈다.
- 타이틀(가운데)는 항상 string만 받아옵니다.

### 우려되는 점
- 왼쪽 title에 string이 아닌 x나 < 과같은 icon이 들어 갈 수 있는데 실제 icon이 들어갔을 때 의도한 대로 잘 나올지 궁금합니다.
- 다용도의 header를 처음 만들어봐서, 이러한 구조로 만드는 것이 좋은 방법인지 우려됩니다.
- style... (담배)